### PR TITLE
Revert "ci python version 3.7"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.7'
+          python-version: '3.6'
       - name: Install pipenv
         run: python -m pip install --upgrade pipenv wheel
       - name: Install dependencies


### PR DESCRIPTION
Reverts VOKO-Utrecht/voko#202

Production server cannot install python3.7, needs upgraded first.
Revert this pull request to not block new releases