### PR TITLE
207 improve user list for rides

### DIFF
--- a/webapp/accounts/admin.py
+++ b/webapp/accounts/admin.py
@@ -270,6 +270,11 @@ class VokoUserBaseAdmin(UserAdmin):
 
 class VokoUserAdmin(HijackUserAdminMixin, VokoUserBaseAdmin):
     list_display = VokoUserBaseAdmin.list_display
+    # Setting search_fields impacts both the user admin page, and the dropdown in
+    # admin/transport/ride/add. In user admin, we should probably search on all fields, but the
+    # dropdown only show first and last name, resulting in 'false positives', e.g. when the email
+    # address matches. For now, we'll just accept that minor inconvenience
+    # search_fields = ["first_name", "last_name"]
 
     actions = (enable_user,
                force_confirm_email,

--- a/webapp/transport/admin.py
+++ b/webapp/transport/admin.py
@@ -46,6 +46,7 @@ class RouteAdmin(admin.ModelAdmin):
 
 class RideAdmin(admin.ModelAdmin):
     list_display = ["date", "route", "driver", "codriver"]
+    autocomplete_fields = ["driver", "codriver"]
     ordering = ("-order_round__collect_datetime", "route")
     list_filter = (RecentListFilter,)
 


### PR DESCRIPTION
This adds a filter option to the (co)driver dropdowns when adding a new ride.

Note: All the user fields are searched, and this may give false positives e.g. when the email address matches the filter. It's easy to search by first and last name only, but this also impacts searching on the user admin page. I haven't found a workaround for that yet