### PR TITLE
fix(css): hamburger menu at custom 1650px breakpoint

### DIFF
--- a/webapp/assets/css/voko.css
+++ b/webapp/assets/css/voko.css
@@ -163,13 +163,13 @@ h4.product-name a {
   color:#000;
 }
 
-@media all and (min-width: 900px) {
+@media all and (min-width: 992px) {
 	.navbar .nav-item .dropdown-menu{ display: none; }
 	.navbar .nav-item:hover .dropdown-menu{ display: block; }
 	.navbar .nav-item .dropdown-menu{ margin-top:0; }
 }
 
-@media (max-width: 900px) {
+@media (max-width: 991.98px) {
 
     .navbar-brand {
         width: 210px;

--- a/webapp/assets/css/voko.css
+++ b/webapp/assets/css/voko.css
@@ -163,13 +163,13 @@ h4.product-name a {
   color:#000;
 }
 
-@media all and (min-width: 992px) {
+@media all and (min-width: 1200px) {
 	.navbar .nav-item .dropdown-menu{ display: none; }
 	.navbar .nav-item:hover .dropdown-menu{ display: block; }
 	.navbar .nav-item .dropdown-menu{ margin-top:0; }
 }
 
-@media (max-width: 991.98px) {
+@media (max-width: 1199.98px) {
 
     .navbar-brand {
         width: 210px;

--- a/webapp/assets/css/voko.css
+++ b/webapp/assets/css/voko.css
@@ -163,13 +163,17 @@ h4.product-name a {
   color:#000;
 }
 
-@media all and (min-width: 1200px) {
+@media all and (min-width: 1650px) {
+	.voko-navbar { flex-wrap: nowrap; justify-content: flex-start; }
+	.voko-navbar .navbar-toggler { display: none; }
+	.voko-navbar .navbar-collapse { display: flex !important; flex-basis: auto; }
+	.voko-navbar .navbar-nav { flex-direction: row; }
 	.navbar .nav-item .dropdown-menu{ display: none; }
 	.navbar .nav-item:hover .dropdown-menu{ display: block; }
 	.navbar .nav-item .dropdown-menu{ margin-top:0; }
 }
 
-@media (max-width: 1199.98px) {
+@media (max-width: 1649.98px) {
 
     .navbar-brand {
         width: 210px;

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -22,7 +22,7 @@
 
   </head>
   <body class="d-flex flex-column h-100 body-background">
-    <nav class="navbar navbar-expand-lg sticky-top nav-background">
+    <nav class="navbar navbar-expand-xl sticky-top nav-background">
       <div class="container-fluid align-items-end px-4">
         <a class="navbar-brand" href="{% url 'home' %}"><img src="{% static 'img/logo-b-mini.png'%}" width="420" height="68"/></a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -22,7 +22,7 @@
 
   </head>
   <body class="d-flex flex-column h-100 body-background">
-    <nav class="navbar navbar-expand-xl sticky-top nav-background">
+    <nav class="navbar voko-navbar sticky-top nav-background sticky-top nav-background">
       <div class="container-fluid align-items-end px-4">
         <a class="navbar-brand" href="{% url 'home' %}"><img src="{% static 'img/logo-b-mini.png'%}" width="420" height="68"/></a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
## Summary

- Fixes the hamburger menu display issue (#370)
- Bootstrap 5's largest built-in breakpoint (`xxl`) is only 1400px, so it can't cover 1650px natively
- Replaced `navbar-expand-xl` with a custom `voko-navbar` class and control the expand/collapse behavior entirely via CSS at 1650px

## Changes

- [base.html](webapp/templates/base.html): `navbar-expand-xl` → `voko-navbar`
- [voko.css](webapp/assets/css/voko.css): custom `min-width: 1650px` rule that shows desktop nav (hides toggler, expands nav inline); mobile styles apply at `max-width: 1649.98px`

Closes #370

## Test plan

- [x] Below 1650px: hamburger toggler is visible and works
- [x] Above 1650px: full desktop nav is shown, no toggler
- [x] Hover dropdowns work on desktop
- [x] Mobile collapsed menu styling looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)