### PR TITLE
fix(ordering): delete unordered products when order round closes

### DIFF
--- a/webapp/ordering/cron.py
+++ b/webapp/ordering/cron.py
@@ -9,7 +9,7 @@ from django.db.models.aggregates import Sum
 from django_cron import CronJobBase, Schedule
 from log import log_event
 
-from ordering.models import Supplier
+from ordering.models import Product, Supplier
 
 from .core import create_orderround_ahead, get_current_order_round, get_latest_order_round, get_next_order_round
 
@@ -122,6 +122,13 @@ class MailOrderLists(CronJobBase):
         # To prevent mail loops
         order_round.order_placed = True
         order_round.save()
+
+        # Remove products that were never ordered (no paid order items)
+        deleted_count, _ = Product.objects.filter(order_round=order_round).exclude(
+            orderproducts__order__paid=True
+        ).delete()
+        if deleted_count:
+            log_event(event="Deleted %d unordered products from order round %d" % (deleted_count, order_round.pk))
 
         for supplier in Supplier.objects.all():
             if not supplier.has_orders_in_current_order_round():

--- a/webapp/ordering/tests/test_cron.py
+++ b/webapp/ordering/tests/test_cron.py
@@ -1,5 +1,6 @@
 from vokou.testing import VokoTestCase
 from ordering.cron import SendPickupReminders, MailOrderLists
+from ordering.models import Product
 from datetime import datetime, timedelta
 from pytz import UTC
 from unittest.mock import patch
@@ -60,3 +61,38 @@ class TestPickupReminderJob(VokoTestCase):
 
             MailOrderLists.do(self)
             self.assertTrue(mock_mail.called)
+
+    def test_unordered_products_are_deleted_when_order_is_placed(self):
+        with patch("django.core.mail.EmailMultiAlternatives.send"):
+            now = datetime.now(tz=UTC)
+            self.order_round = OrderRoundFactory(
+                open_for_orders=now - timedelta(days=4),
+                closed_for_orders=now - timedelta(days=1),
+                collect_datetime=now + timedelta(hours=1),
+            )
+            ordered_product = ProductFactory(order_round=self.order_round, maximum_total_order=10)
+            unordered_product = ProductFactory(order_round=self.order_round)
+
+            order = OrderFactory(order_round=self.order_round, finalized=True, paid=True)
+            OrderProductFactory(order=order, product=ordered_product, amount=1)
+
+            MailOrderLists.do(self)
+
+            self.assertTrue(Product.objects.filter(pk=ordered_product.pk).exists())
+            self.assertFalse(Product.objects.filter(pk=unordered_product.pk).exists())
+
+    def test_products_with_only_unpaid_orders_are_deleted_when_order_is_placed(self):
+        with patch("django.core.mail.EmailMultiAlternatives.send"):
+            now = datetime.now(tz=UTC)
+            self.order_round = OrderRoundFactory(
+                open_for_orders=now - timedelta(days=4),
+                closed_for_orders=now - timedelta(days=1),
+                collect_datetime=now + timedelta(hours=1),
+            )
+            product = ProductFactory(order_round=self.order_round)
+            unpaid_order = OrderFactory(order_round=self.order_round, finalized=True, paid=False)
+            OrderProductFactory(order=unpaid_order, product=product, amount=1)
+
+            MailOrderLists.do(self)
+
+            self.assertFalse(Product.objects.filter(pk=product.pk).exists())


### PR DESCRIPTION
## Summary

- When `MailOrderLists` processes a closed order round, all products from that round with no paid order items are now deleted
- This covers products that were never ordered at all, and products where orders existed but were never paid
- Addresses ~50% product cleanup mentioned in the issue

## Test plan

- [x] `test_unordered_products_are_deleted_when_order_is_placed` — verifies unordered product is deleted while ordered product survives
- [x] `test_products_with_only_unpaid_orders_are_deleted_when_order_is_placed` — verifies products with only unpaid orders are also cleaned up
- [x] All existing cron tests still pass

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)