### PR TITLE
Bugs/product category not found

### DIFF
--- a/webapp/ordering/models.py
+++ b/webapp/ordering/models.py
@@ -1093,7 +1093,7 @@ class DraftProduct(TimeStampedModel):
 
         if self.data["category"]:
             try:
-                prod.category = ProductCategory.objects.get(name__iexact=self.data["category"])
+                prod.category = ProductCategory.objects.get(name__iexact=self.data["category"].strip())
                 prod.save()
             except ProductCategory.DoesNotExist:
                 pass

--- a/webapp/templates/ordering/admin/create_draft_products.html
+++ b/webapp/templates/ordering/admin/create_draft_products.html
@@ -51,7 +51,7 @@ De bestelronde is gesloten. Je kunt geen producten toevoegen.
             <select class="form-control" name="product_category_{{ forloop.counter }}">
                 <option>Overig</option>
                 {% for cat in view.category_choices %}
-                <option {% if product.category == cat %}selected{% endif %}>{{ cat }}</option>
+                <option {% if product.category.strip|lower == cat|lower %}selected{% endif %}>{{ cat }}</option>
                 {% endfor %}
             </select>
         </td>


### PR DESCRIPTION
This PR fixes an issue where products in an uploaded Excel do not have an exact matching category, e.g. `fruit`, `Fruit` or `Fruit `. 
- The overview table of draft products will show the correct category in the dropdown
- The 'real' product will reference the correct category